### PR TITLE
Support g_bytes_get_data()

### DIFF
--- a/lib.in/glib-2.0/config.json
+++ b/lib.in/glib-2.0/config.json
@@ -43,7 +43,6 @@
     },
     "method-blacklist": {
 	"Bytes": [
-	    "get_data",
 	    "unref_to_array"
 	],
 	"Variant": [


### PR DESCRIPTION
I don't know why `g_bytes_get_data()` is blacklisted but how about this implementation?
I think that returning `[]byte` not `size uint64, data []uint8` is suitable for `g_bytes_get_data()`.