### PR TITLE
Install missing Typelib file for GUdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and the orignal author [nsf](https://github.com/nsf/gogobject).
 Install prerequisites
 
 ```
-$ apt-get install libgirepository1.0-dev
+$ apt-get install libgirepository1.0-dev libgudev-1.0-dev
 $ make install
 ```
 


### PR DESCRIPTION
Without it, it fails to build:

  $ make
  mkdir -p out/src/gir
  cd src/gir-generator && go build  -o /home/kenhys/.local/src/github.com/linuxdeepin/go-gir-generator/out/gir-generator
  out/gir-generator -o  out/src/gir/glib-2.0 lib.in/glib-2.0/glib.go.in
  out/gir-generator -o out/src/gir/gobject-2.0 lib.in/gobject-2.0/gobject.go.in
  out/gir-generator -o out/src/gir/gio-2.0 lib.in/gio-2.0/gio.go.in
  out/gir-generator -o out/src/gir/gudev-1.0 lib.in/gudev-1.0/gudev.go.in
  panic: Typelib file for namespace 'GUdev', version '1.0' not found
  goroutine 1 [running]: