### PR TITLE
Fix compatibility with glib 2.63+

### DIFF
--- a/.github/workflows/call-clacheck.yml
+++ b/.github/workflows/call-clacheck.yml
@@ -1,0 +1,16 @@
+name: Call CLA check
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-pull/${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  clacheck:
+    uses: linuxdeepin/.github/.github/workflows/cla-check.yml@master
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/lib.in/gio-2.0/config.json
+++ b/lib.in/gio-2.0/config.json
@@ -222,7 +222,8 @@
 			"launch_uris_as_manager_with_fds"
 		],
 		"Cancellable": [
-			"connect"
+			"connect",
+			"source_new"
 		],
 		"Application": [
 			"get_dbus_connection"


### PR DESCRIPTION
This fixes the following error when building with new glib:

```
# pkg.deepin.io/gir/gio-2.0 [pkg.deepin.io/gir/gio-2.0.test]
gio-2.0/gio.go:1504:40: undefined: glib.Source
gio-2.0/gio.go:1510:12: undefined: glib.Source
gio-2.0/gio.go:1513:11: undefined: glib.Source
```