### PR TITLE
chore: modify README license information

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -8,10 +8,15 @@ Files: .gitignore .clang-format .gitreview .mailmap .tx/config
 Copyright: None
 License: CC0-1.0
 
-# Project file
-Files: *Makefile* gogtk-demo/wscript lib.in/cairo-1.0/types_386.go lib.in/cairo-1.0/types_amd64.go
+# Makefile
+Files: *Makefile*
 Copyright: None
 License: CC0-1.0
+
+# Project file
+Files: gogtk-demo/wscript lib.in/cairo-1.0/types_386.go lib.in/cairo-1.0/types_amd64.go
+Copyright: None
+License: GPL-3.0-or-later
 
 # ci
 Files: .github/* .gitlab-ci.yml
@@ -46,4 +51,5 @@ License: GPL-3.0-or-later
 # go vendor dir
 Files: vendor/*
 Copyright: UnionTech Software Technology Co., Ltd.
-License: CC0-1.0
+License: GPL-3.0-or-later
+

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ We encourage you to report issues and contribute changes
 
 ## License
 
-go-gir-generator is licensed under [GPLv3](LICENSE).
+go-gir-generator is licensed under [GPL-3.0-or-later](LICENSE).
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -62,5 +62,5 @@ gir-generator -o . gobject.go.in
 * [Contribution guide for developers](http://wiki.deepin.org/index.php?title=Contribution_Guidelines_for_Developers)
 
 ## 开源许可
-go-gir-generator项目在LGPL-3.0-or-later开源协议下发布。
+go-gir-generator项目在[GPL-3.0-or-later](LICENSE)开源协议下发布。
 


### PR DESCRIPTION
The protocol name in the README is written according to the standard specification

Log: modify README license information
Influence: none
Task: https://pms.uniontech.com/task-view-185215.html
Change-Id: Id75f9b8dbc18f235cd0eb16795768ff25038e014