### PR TITLE
fix: catch file close error

### DIFF
--- a/generator/binding_generator.go
+++ b/generator/binding_generator.go
@@ -50,9 +50,12 @@ func (this *binding_generator) release() {
 	this.out_go.Flush()
 	this.out_c.Flush()
 	this.out_h.Flush()
-	this.file_go.Close()
-	this.file_c.Close()
-	this.file_h.Close()
+	err := this.file_go.Close()
+	panic_if_error(err)
+	err = this.file_c.Close()
+	panic_if_error(err)
+	err = this.file_h.Close()
+	panic_if_error(err)
 }
 
 func (this *binding_generator) generate(go_template string) {

--- a/generator/main.go
+++ b/generator/main.go
@@ -166,7 +166,11 @@ func parse_json_with_comments(filename string, data interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			panic(err)
+		}
+	}()
 
 	d := json.NewDecoder(new_comment_skipper(f))
 	err = d.Decode(data)


### PR DESCRIPTION
catch the return value of file Close function, and report an exception when it is not nil

Log: catch file close error