### PR TITLE
chore: bump version to 3.0.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+go-gir-generator (3.0.6) unstable; urgency=medium
+
+  * Release 3.0.6
+
+ -- fuleyi <fuleyi@uniontech.com>  Thu, 04 Dec 2025 19:14:47 +0800
+
 go-gir-generator (3.0.5) unstable; urgency=medium
 
   * feat: 添加ContentTypeGuess函数


### PR DESCRIPTION
update changelog to 3.0.6